### PR TITLE
Fixes Occasional Failure To Start Autosplitter

### DIFF
--- a/Clustertruck.asl
+++ b/Clustertruck.asl
@@ -45,7 +45,7 @@ startup
 
 start
 {
-	if (current.levelSelect == 108 && vars.areaLevel == 1 && old.LevelTime == 0 && current.LevelTime <= 1 && current.LevelTime > 0)
+	if (current.levelSelect == 108 && vars.areaLevel == 1 && old.LevelTime == 0 && current.LevelTime > 0)
 	{
 	        return true;
 	}


### PR DESCRIPTION
Fixes issue #12 with the occasional failure to start splitter. Removing this check fixes the code so far as I can see, but you can test this for yourself of course. Can't replicated #12 if I do remove the code though making me think this fixes it.