### PR TITLE
Renamed fullgame setting to split by level again

### DIFF
--- a/Clustertruck.asl
+++ b/Clustertruck.asl
@@ -51,8 +51,8 @@ update
 
 startup
 {
-	settings.Add("levelSplit", true, "Full Game");
-	settings.SetToolTip("levelSplit", "This is the default way to run the game from 1:1 to the end");
+	settings.Add("levelSplit", true, "Split by Level");
+	settings.SetToolTip("levelSplit", "True splits per level, false splits per world.");
 	//settings.Add("worldSplit", false, "Individual Worlds");
 	//settings.SetToolTip("worldSplit", "This will allow you to run individual worlds instead of the whole game (Overides any%)");
 	settings.Add("devMode", false, "Dev Mode");


### PR DESCRIPTION
You don't need to merge if you already did this in your code. This is just old settings code that was removed through recent commits.