### PR TITLE
Initialization Bug Check

### DIFF
--- a/Clustertruck.asl
+++ b/Clustertruck.asl
@@ -109,7 +109,7 @@ split {
 reset {
 	// If in menu or reset in first level, restart the timer if reset option is on
 	// Adjust current.mapTime <= 0.01 if there are any issues with it not resetting
-	return (!old.isInMenu && current.isInMenu) || (current.level % 10 == 1 &&  vars.currentSplit == 0 && current.mapTime <= 0.01);
+	return (!old.isInMenu && current.isInMenu) || (current.level % 10 == 1 &&  vars.currentSplit == 0 && current.mapTime <= 0.01 && current.workshopTime != 0);
 }
 
 isLoading {


### PR DESCRIPTION
On startup, workshop time is not initialized and for some reason, this means the map time and all other form of timers will restart to 0 once that time is set to a value. The extra check prevents the new restart functionality from working until the workshop time is initialized (aka a level is finished). This is a tiny bit of a bug with the autosplitter, but to be fair it's only a bug with the new restart functionality itself and now shouldn't affect anyone in a meaningful way. 

I don't understand why Clustertruck has weird value initialization on the first run, but whatever.