### PR TITLE
Updated Clustertruck.asl

### DIFF
--- a/Clustertruck.asl
+++ b/Clustertruck.asl
@@ -1,153 +1,178 @@
-/*
- * GameManager : "mono.dll", 0x1F36AC, 0x20, 0xE80, 0x1C, 0x14   * info : "mono.dll", 0x20B574, 0x10, 0x158
- * * 0x0, 0xC : static fields,                                   * * 0x4        : darkWorld (bool),
- *   * 0x0 : mapTime (float),                                    * * 0x10       : truckWidth (float),
- *   * 0x4 : totalTime (float),                                  * * 0x14       : drag (float),
- *   * 0x8 : mapDeaths (int),                                    * * 0x18       : speedMultiplier (float),
- *   * 0xC : totalDeaths (int)                                   * * 0x1C       : scoreMultiplier (float),
- * *                                                             * * 0x20, 0x14 : abilityName (string),
- * * 0x14 : player,                                              * * 0x24, 0x14 : utilityName (string),
- *   * 0x7C : canMove (bool),                                    * * 0x28       : levelLength (float),
- *   * 0x7D : dead (bool),                                       * * 0x2C       : lastPlayedLevel (int),
- *   * 0x7E : frozen (bool),                                     * * 0x30       : onLastLevel (bool),
- *   * 0x88 : framesSinceStart (float),                          * * 0x31       : playing (bool),
- *   * 0x90 : running (bool),                                    * * 0x34       : pauseFrames (int),
- *   * 0x91 : walking (bool),                                    * * 0x38       : paused (bool),
- *   * 0xD0 : boosting (bool),                                   * * 0x44       : currentChristmasLevel (int),
- * * 0x5C : done (bool),                                         * * 0x50       : currentHalloweenLevel (int),
- * * 0x5D : won (bool),                                          * * 0x54       : currentLevel (int),
- * * 0x68 : sinceWon (float)                                     * * 0x58       : currentWorld (int)
- *
- * steam_WorkshopHandler : "mono.dll", 0x20B574, 0x10, 0x130, 0x4
- * * 0x78, 0x14 : RealMapName (string),
- * * 0x90       : time (float),
- * * 0x94       : score (int),
- * * 0x98       : currentRetryCount (int)
- */
+/* MEMORY POINTERS TREE FROM THE SOURCE CODE, * are already in use
 
-state("Clustertruck") {
-	float workshopTime     : "mono.dll", 0x20B574, 0x10, 0x130, 0x4, 0x90;
+GameManager: "mono.dll", 0x1F36AC, 0x20, 0xE80, 0x1C, 0x14    info : "mono.dll", 0x20B574, 0x10, 0x158
+│                                                             │
+├─── 0x0, 0xC : static fields                                 ├─── 0x4        : darkWorld (bool)
+│    ├─── 0x0 : mapTime (float)                               ├─── 0x10       : truckWidth (float)
+│    ├─── 0x4 : totalTime (float)                             ├─── 0x14       : drag (float)
+│    ├─── 0x8 : mapDeaths (int)                               ├─── 0x18       : speedMultiplier (float)
+│    └─── 0xC : totalDeaths (int)                             ├─── 0x1C       : scoreMultiplier (float)
+│                                                             ├─── 0x20, 0x14 : abilityName (string)
+├─── 0x14 : player                                            ├─── 0x24, 0x14 : utilityName (string)
+│    ├─── 0x7C : canMove (bool)                               ├─── 0x28       : levelLength (float)
+│    ├─── 0x7D : dead (bool)                                  ├─── 0x2C       : previousLevel (int)
+│    ├─── 0x7E : frozen (bool)                                ├─── 0x30       : onLastLevel (bool)
+│    ├─── 0x88 : framesSinceStart (float)                     ├─── 0x31       : playing (bool)
+│    ├─── 0x90 : running (bool)                               ├─── 0x34       : pauseFrames (int)
+│    ├─── 0x91 : walking (bool)                               ├─── 0x38       : paused (bool)
+│    └─── 0xD0 : boosting (bool)                              ├─── 0x44       : currentChristmasLevel (int)
+│                                                             ├─── 0x50       : currentHalloweenLevel (int)
+├─── 0x5C : done (bool)                                       ├─── 0x54       : currentLevel (int)
+├─── 0x5D : won (bool)                                        └─── 0x58       : currentWorld (int)
+└─── 0x68 : sinceWon (float)
 
-	int level              : "mono.dll", 0x20B574, 0x10, 0x158, 0x54;
-	int christmasLevel     : "mono.dll", 0x20B574, 0x10, 0x158, 0x44;
-	int halloweenLevel     : "mono.dll", 0x20B574, 0x10, 0x158, 0x50; 
-	int world              : "mono.dll", 0x20B574, 0x10, 0x158, 0x58;
+steam_WorkshopHandler : "mono.dll", 0x20B574, 0x10, 0x130, 0x4
+│
+├─── 0x78, 0x14 : RealMapName (string)
+├─── 0x90       : time (float)
+├─── 0x94       : score (int)
+└─── 0x98       : currentRetryCount (int)
+*/
 
-	float gameTimer        : "mono.dll", 0x1F36AC, 0x20, 0xE80, 0x1C, 0x14, 0x0, 0xC, 0x0; // mapTime
-	bool isDead            : "mono.dll", 0x1F36AC, 0x20, 0xE80, 0x1C, 0x14, 0x14, 0x7D; // dead
-	float framesSinceStart : "mono.dll", 0x1F36AC, 0x20, 0xE80, 0x1C, 0x14, 0x14, 0x88;
-
-	int inMenuVal          : "mono.dll", 0x1F30AC, 0x7D4, 0xC, 0x40, 0x90;
+state("Clustertruck", "v1.1") {
+	float levelTime         : "mono.dll", 0x1F36AC, 0x20, 0xE80, 0x1C, 0x14, 0x0, 0xC, 0x0; // Pointer: GameManager > static fields > mapTime (float) 
+	float framesSinceStart  : "mono.dll", 0x1F36AC, 0x20, 0xE80, 0x1C, 0x14, 0x14, 0x88;    // Pointer: GameManager > player > framesSinceStart (float) 
+	float levelCompleteTime : "mono.dll", 0x20B574, 0x10, 0x130, 0x4, 0x90;                 // Pointer: steam_WorkshopHandler > time (float)
+	
+	bool isDead    : "mono.dll", 0x1F36AC, 0x20, 0xE80, 0x1C, 0x14, 0x14, 0x7D; // Pointer: GameManager > player > dead (bool) 
+	int  inMenuVal : "mono.dll", 0x1F30AC, 0x7D4, 0xC, 0x40, 0x90;              // Why is inMenuVal not in the pointertree?
+	
+	int christmasLevel : "mono.dll", 0x20B574, 0x10, 0x158, 0x44; // Pointer: info > currentChristmasLevel (int)
+	int halloweenLevel : "mono.dll", 0x20B574, 0x10, 0x158, 0x50; // Pointer: info > currentHalloweenLevel (int)
+	int level          : "mono.dll", 0x20B574, 0x10, 0x158, 0x54; // Pointer: info > currentLevel (int)
+	int world          : "mono.dll", 0x20B574, 0x10, 0x158, 0x58; // Pointer: info > currentWorld (int)
 }
 
+
+// Runs when the script is first loaded
 startup {
-	// Setting initialization
-	Object[,] settingsArray = new Object[,] {
-		{"reset", true, "Reset", "By itself does nothing, enable other reset options for it to do anything. False means other options are disabled", null},
-		{"resetFirstLevel", true, "Reset First Level", "Autosplitter resets when you restart or die on the first level", "reset"},
-		{"resetLevelBackwards", true, "Reset if Level Backwards", "Autosplitter resets if the level number decrements like if the player selects an earlier level", "reset"},
-		{"resetOnDeath", true, "Reset on Death", "Autosplitter resets when the player dies", "reset"},
-		{"resetInMenu", false, "Reset in Menu", "Autosplitter resets when going to the menu", "reset"},
-		{"levelSplit", true, "Split by Level", "On splits per level, off splits per world.", null},
-		{"onlyStartFromLoad", false, "Only Start From Level Load", "Results in the timer only starting when loading\na level from the level select screen", null},
-		{"startEveryLevel", false, "Start on Every Level", "Use this if you want to time ILs (empty split file recommended)", null},
-		{"devMode", false, "Developer Mode", "This enables developer mode, allowing for debugging", null}
+	// Settings initialisation
+	Object[,] settingsArray = new Object[,] { // trademark Noah :)
+	//	| ID                   | Dflt  | Name                 | Parent  | Description                                                                 |
+		{ "reset"              , true  , "Reset"              , null    , "Disable or enable all automatic reset functionality."                      },
+		{ "resetFirstLevel"    , true  , "In first level"     , "reset" , "Reset the timer when you restart or die on the first level."               },
+		{ "resetPreviousLevel" , true  , "On previous level"  , "reset" , "Reset the timer when a previous level is selected."                        },
+		{ "resetOnDeath"       , true  , "On death"           , "reset" , "Reset the timer when the player dies."                                     },
+		{ "resetInMenu"        , false , "In menu"            , "reset" , "Reset the timer when going to the menu."                                   },
+		{ "splitByLevel"       , true  , "Split by level"     , null    , "Enable to use level splits, disable to use world splits."                  },
+		{ "startInLevel"       , true  , "Start in level"     , null    , "Start the timer when restarting in a level."                               },
+		{ "startAnyLevel"      , false , "Start in any level" , null    , "Start the timer in any level, instead of only the first (useful for ILs)." },
+		{ "debugMode"          , false , "Debug mode"         , null    , "Enables debugging logging. Use debugview to view output."                  }
 	};
+	
 	for (int i = 0; i < settingsArray.GetLength(0); i++) {
-		settings.Add((string)settingsArray[i, 0], (bool)settingsArray[i, 1], (string)settingsArray[i, 2], (string)settingsArray[i, 4]);
-  		settings.SetToolTip((string)settingsArray[i, 0], (string)settingsArray[i, 3]);
+		string setId          = settingsArray[i, 0];
+		bool   setDefault     = settingsArray[i, 1];
+		string setName        = settingsArray[i, 2]; // Called description by livesplit.
+		string setParent      = settingsArray[i, 3]; // appending ``?? null`` to this removes the need to have null specified in the above settings array.
+		string setDescription = settingsArray[i, 4]; // Called tooltip by livesplit.
+
+		settings.Add(setId, setDefault, setName, setParent);
+		settings.SetToolTip(setId, setDescription);
 	}
 
-	refreshRate = 1000;
+	refreshRate = 1000; // Change in future? 1000 is a bit much when the default is 60.
 }
 
+
+// Runs when the game process is found.
 init {
-	vars.lastPlayedLevel = 0;
-	vars.lastPlayedChristmasLevel = 0;
+	version = "v1.1"; // We only support the latest version of the game.
+	vars.previousLevel = 0;
+	vars.previousChristmasLevel = 0;
 	vars.levelsCompleted = 0;
 }
 
+
+// The update action always runs first.
 update {
-	// Don't run checking unless inMenuVal initialized
-	if (current.inMenuVal == 0) {
-		return false;	
-	}
+	if (current.inMenuVal == 0) { return false; } // Don't run the next actions unless inMenuVal initialized.
 
-	// Set boolean for is in menu instead of random constant
-	current.isInMenu = current.inMenuVal != 108 && current.inMenuVal != 109;
-	vars.firstGameplayFrame = old.framesSinceStart == 0 && current.framesSinceStart > 0;
-	vars.firstLevelCompleteFrame = old.workshopTime != current.workshopTime;
+	current.isInMenu = (current.inMenuVal != 108 && current.inMenuVal != 109); // Set boolean for is in menu instead of random constant.
+	vars.firstGameplayFrame = (old.framesSinceStart == 0 && current.framesSinceStart > 0);
+	vars.firstLevelCompleteFrame = (old.levelCompleteTime != current.levelCompleteTime);
 
-	// A player spawn happens when a player enters a level, dies, or restarts a level. Important for resetOnRestart
-	if(current.level != old.level) {
-		vars.lastPlayedLevel = old.level;	
-		// Try removing this I dare you, the problem here is its not enough to just say current.christmasLevel = 5 because that never changes once you leave the world
-		vars.lastPlayedChristmasLevel = old.christmasLevel;
-	}
 
-	if (settings["devMode"]) {
+	// Surely this entire (indented) section could be put in the split action? Also keep in mind restarting is allowed for the first 2 seconds of a level for deathless categories.
+		if (current.level != old.level) { // A player spawn happens when a player enters a level, dies, or restarts a level. Important for resetOnRestart.
+			vars.previousLevel = old.level;
+			vars.previousChristmasLevel = old.christmasLevel; // Try removing this I dare you, the problem here is it's not enough to just say current.christmasLevel = 5 because that never changes once you leave the world.
+		}
+
+	if (settings["debugMode"]) {
 		print("------------------------------");
-		print("Current Level: " + current.level);
-		print("Current Christmas Level: " + current.christmasLevel);
-		print("Current Halloween Level: " + current.halloweenLevel);
-		print("Last Played Level: " + vars.lastPlayedLevel);
-		print("Current World: " + current.world);
-		print("Levels Completed: " + vars.levelsCompleted);
-		print("Is In Menu: " + current.isInMenu);
-		print("Game Timer: " + current.gameTimer);
+		print("World:              " + current.world);
+		print("Level:              " + current.level);
+		print("Christmas Level:    " + current.christmasLevel);
+		print("Halloween Level:    " + current.halloweenLevel);
+		print("Last Played Level:  " + vars.previousLevel);
+		print("Levels Completed:   " + vars.levelsCompleted);
+		print("Is In Menu:         " + current.isInMenu);
+		print("Level Time:         " + current.levelTime);
 		print("Frames Since Start: " + current.framesSinceStart);
-		print("Is Dead: " + current.isDead);
+		print("Is Dead:            " + current.isDead);
 	}
 }
 
+
+// Doesn't run if the update action returns false OR the timer has already been started.
 start {
-	bool start = 	
-		(!settings["onlyStartFromLoad"] || old.isInMenu) && 
-		!current.isInMenu && 
-		(settings["startEveryLevel"] ? true : current.level % 10 == 1) && 
-		vars.firstGameplayFrame;
+	bool start = ( 
+		(settings["startInLevel"] || old.isInMenu) &&
+		!current.isInMenu &&
+		(settings["startAnyLevel"] || current.level % 10 == 1) &&
+		vars.firstGameplayFrame
+	);
 
 	if (start) {
 		vars.levelsCompleted = 0;
-		current.playerSpawns = 0;
-		vars.lastPlayedLevel = current.level;
-		vars.lastPlayedChristmasLevel = current.christmasLevel;
+		current.playerSpawns = 0; // Unused, I'll assume you were doing something with it :P
+		vars.previousLevel = current.level;
+		vars.previousChristmasLevel = current.christmasLevel;
 		return true;
 	}
 }
 
-split {
-	if(vars.firstLevelCompleteFrame)
-	{
-		vars.levelsCompleted++;
-		return 
-			settings["levelSplit"] ||
-			current.level % 10 == 0 || 
-			(current.christmasLevel == 5 && vars.lastPlayedChristmasLevel == 4);
-	}
-}
 
-reset {
-	// 0.01s, if the time is 0 again, then we want to reset
-	bool resetInLevel = 
-		settings["resetFirstLevel"] && 
-		(settings["startEveryLevel"] ? true : vars.levelsCompleted == 0) && 
-		current.gameTimer < 0.01 && 
-		current.workshopTime != 0;
-
-	bool resetBackwards = 
-		settings["resetLevelBackwards"] && current.level - vars.lastPlayedLevel <= -1 && !current.isInMenu &&
-		!(current.christmasLevel == 5 && current.halloweenLevel == 1) &&
-		!(current.halloweenLevel == 10 && current.level == 1 && vars.levelsCompleted == 15);
-
-	bool resetMenu = settings["resetInMenu"] && current.isInMenu && !old.isInMenu;
-	bool resetOnDeath = settings["resetOnDeath"] && current.isDead;
-
-	return resetInLevel || resetBackwards || resetMenu || resetOnDeath;
-}
-
+// Doesn't run if the update action returns false.
 isLoading {
-	bool isPlaying = vars.firstGameplayFrame || current.isInMenu;
+	bool isPlaying = (vars.firstGameplayFrame || current.isInMenu);
 	if (vars.firstLevelCompleteFrame) { return true; }
 	if (isPlaying) { return false; }
+}
+
+
+// Doesn't run if the update action returns false.
+reset {
+	bool resetFirstLevel = (
+		settings["resetFirstLevel"] && 
+		(settings["startAnyLevel"] || vars.levelsCompleted == 0) &&
+		current.levelTime < 0.01 && 
+		current.levelCompleteTime != 0
+	);
+
+	bool resetPreviousLevel = (
+		settings["resetPreviousLevel"] && 
+		(current.level - vars.previousLevel <= -1 && !current.isInMenu) && 
+		!(current.christmasLevel == 5 && current.halloweenLevel == 1) &&                    // Don't reset when going from Holidays:5 to Halloween:1
+		!(current.halloweenLevel == 10 && current.level == 1 && vars.levelsCompleted == 15) // Don't reset when going from Halloween:10 to 1:1
+	);
+
+	bool resetInMenu  = (settings["resetInMenu"] && current.isInMenu && !old.isInMenu);
+	bool resetOnDeath = (settings["resetOnDeath"] && current.isDead);
+
+	return resetFirstLevel || resetPreviousLevel || resetInMenu || resetOnDeath;
+}
+
+
+// Doesn't run if the reset action returns true
+split {
+	if (vars.firstLevelCompleteFrame) {
+		vars.levelsCompleted++;
+		return (
+			settings["splitByLevel"] || 
+			current.level % 10 == 0 || 
+			(current.christmasLevel == 5 && vars.previousChristmasLevel == 4) // Split on Christmas:5 for split by world because christmas only goes to 5.
+		);
+	}
 }


### PR DESCRIPTION
Did some formatting and cleaning up. These changes shouldn't be breaking since they're only changes to the look of the code and not the functionality. Nevertheless I would still test it before approving the pull request. Changelog:

General changes:
- Formatted the pointer tree into a proper tree to increase readability.
- Added parenthesis around all boolean condition assignments to more clearly communicate that we're looking at condition assignments and not e.g. shorthand assignments.
- Changed order of the actions in the code to reflect their execution order.
- Added a comment above every action indicating the conditions for it to run.
- Changed newline comments meant for only one line to be inline and inline comments meant for a block of code to be newline.
- Added comments here and there with questions to other devs and explanations of non-self explanatory code.

Changes specific to individual actions:

state:
- Added versioning.
- Ordered and grouped pointer variables and added comments with the pointer tree path.
- Renamed float workshopTime to levelCompleteTime to more accurately reflect and its values.
- Renamed float gameTimer to levelTime to more accurately reflect its values.

startup:
- Formatted settingsArray into a proper table with headers to increase readability.
- Switched positions of parent and description array entries to increase readability.
- Reworked all setting descriptions to better communicate their actions.
- Removed "Reset" from the names (not IDs) of all settings parented to the "reset" variable, as them being parented already communicates their reset action.
- Renamed setting resetLevelBackwards (name: "Reset if level backwards") to resetPreviousLevel (name: "On previous level") to better communicate its actions.
- Renamed setting id levelSplit to splitByLevel to conform with the rest of the code and to better communicate it's actions.
- Renamed setting onlyStartFromLoad (name: "Only Start From Level Load") to startInLevel (name: "Start in level") and set the default from false to true (to account for the removal of the negation in the name). This was done to make the setting easier to comprehend and conform better with the rest of the code.
- Renamed setting startEveryLevel (name: "Start on Every Level") to startAnyLevel (name: "Start in any level") to better communicate its actions.
- Renamed settings devMode (name: "Developer Mode") to debugMode (name: "Debug mode") to better communicate its actions.
- Added temporary variables in the for loop for every settings array entry to make it easier to read and comprehend.

init:
- Added version assignment.
- Renamed lastPlayedLevel to previousLevel.
- Renamed lastPlayedChristmasLevel to previousChristmasLevel.

update:
- Changed debug mode print strings to all have the values inline to make them easier to read during debugging.

start:
- Changed the conditional/ternary operator to an or operator since it was unnecessary.

reset:
- Changed the conditional/ternary operator to an or operator since it was unnecessary.
- Added comments explaining the previous level reset exceptions for Holidays:5 to Halloween:1 and Halloween:10 to 1:1.

split:
- Added comment explaining the split condition for Christmas:5.

I think I got all of the changes in the changelog. Feel free to roll back any changes you don't like, although I'd love to hear the feedback and discuss them instead :)